### PR TITLE
VW PQ: HCA 7 mode switching (#54)

### DIFF
--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -1,8 +1,9 @@
-def create_steering_control(packer, bus, apply_steer, lkas_enabled):
+def create_steering_control(packer, bus, apply_steer, lkas_enabled, hca_mode):
+
   values = {
     "LM_Offset": abs(apply_steer),
     "LM_OffSign": 1 if apply_steer < 0 else 0,
-    "HCA_Status": 7 if (lkas_enabled and apply_steer != 0) else 3,
+    "HCA_Status": hca_mode if (lkas_enabled and apply_steer != 0) else 3,
     "Vib_Freq": 16,
   }
 


### PR DESCRIPTION
This code allows the active HCA mode for VW PQ vehicles to selectively switch between 5 and 7.

5 is great for highway and mostly straight roads. 7 is great for turns!

Driving is still a bit rough around the edges for now, but this is the smoothest we have gotten the handoffs between modes to occur

Commits:
* initial hca_mode flipping commit

* hot fix**ing**

* bump hysteresis to 5 deg

* increase hysteresis to 13 degree's

* change HCA flipping logic.

* logic change worked, dropping hysteresis limits to test

* switch to NM torque blending

* temporarily bump panda maxsteer to 400

* revert panda edit, refactor torque blend

* refactor, again!

* try ramping the 1NM drop

* bugfix for pseudo STEER_MAX?

* another hotfix

* change rate limit in interpolation, removed apply_driver_steer_torque_limit

* throw out >3nm. switch to HCA7 when requested torque >2nm

* make HCA7 switching a wider band, and add some torque interpolation

* change flipping logic

* fix typo

* bugfix: negative steering angle

* switch to hca7 based on NM rate too

* change from NM rate to steeringRate

* revert back to no rate based hca7 switch

* up deadzone to 13

* 13 up for HCA7 worked, dropping HCA5 down to 8

* fix bug, > not < !

* bugfix: hca7 lock and unlock logic. fixed for reals now!