### PR TITLE
VW PQ: ECD testing on mk60ec1 CC firmware (#59)

### DIFF
--- a/selfdrive/car/volkswagen/carcontroller.py
+++ b/selfdrive/car/volkswagen/carcontroller.py
@@ -23,6 +23,8 @@ class CarController:
     self.frame = 0
     self.hcaSameTorqueCount = 0
     self.hcaEnabledFrameCount = 0
+    self.EPB_brake = 0
+    self.EPB_enable = 0
 
   def update(self, CC, CS, ext_bus, now_nanos):
     actuators = CC.actuators
@@ -73,9 +75,21 @@ class CarController:
 
     if self.frame % self.CCP.ACC_CONTROL_STEP == 0 and self.CP.openpilotLongitudinalControl:
       acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
-      accel = clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0
       stopping = actuators.longControlState == LongCtrlState.stopping
-      starting = actuators.longControlState == LongCtrlState.starting
+      starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < self.CP.vEgoStopping)
+      if self.CCS == pqcan and CC.longActive and (clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) <= 0) and CS.out.vEgoRaw <= 5:
+        accel = 0
+        stopping = 1 if CS.out.vEgoRaw <= 3 else 0
+        if not self.EPB_enable:
+          self.EPB_enable = 1
+          self.EPB_brake = 0
+        else:
+          self.EPB_brake = clip(actuators.accel, self.CCP.ACCEL_MIN, 0)
+      else:
+        accel = clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0
+        self.EPB_enable = 0
+        self.EPB_brake = 0
+      can_sends.append(self.CCS.create_epb_control(self.packer_pt, CANBUS.br, self.EPB_brake, self.EPB_enable))
       can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, CANBUS.pt, CS.acc_type, CC.longActive, accel,
                                                          acc_control, stopping, starting, CS.esp_hold_confirmation))
 

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -227,7 +227,7 @@ class CarState(CarStateBase):
 
     # Update ACC radar status.
     self.acc_type = ext_cp.vl["ACC_System"]["ACS_Typ_ACC"]
-    ret.cruiseState.available = bool(pt_cp.vl["Motor_5"]["GRA_Hauptschalter"])
+    ret.cruiseState.available = True
     ret.cruiseState.enabled = pt_cp.vl["Motor_2"]["GRA_Status"] in (1, 2)
     if self.CP.pcmCruise:
       ret.accFaulted = ext_cp.vl["ACC_GRA_Anzeige"]["ACA_StaACC"] in (6, 7)

--- a/selfdrive/car/volkswagen/pqcan.py
+++ b/selfdrive/car/volkswagen/pqcan.py
@@ -66,7 +66,7 @@ def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_cont
     "ACS_Sta_ADR": acc_control,
     "ACS_StSt_Info": acc_enabled,
     "ACS_Typ_ACC": acc_type,
-    "ACS_Anhaltewunsch": acc_type == 1 and stopping,
+    "ACS_Anhaltewunsch": 0,
     "ACS_FreigSollB": acc_enabled,
     "ACS_Sollbeschl": accel if acc_enabled else 3.01,
     "ACS_zul_Regelabw": 0.2 if acc_enabled else 1.27,
@@ -76,6 +76,23 @@ def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_cont
   commands.append(packer.make_can_msg("ACC_System", bus, values))
 
   return commands
+
+def create_epb_control(packer, bus, apply_brake, epb_enabled):
+
+  values = {
+    "EP1_Fehler_Sta": 0,
+    "EP1_Sta_EPB": 0,
+    "EP1_Spannkraft": 0,
+    "EP1_Schalterinfo": 0,
+    "EP1_Fkt_Lampe": 0,
+    "EP1_Verzoegerung": apply_brake,                        #Brake request in m/s2
+    "EP1_Freigabe_Ver": 1 if epb_enabled else 0,            #Allow braking pressure to build.
+    "EP1_Bremslicht": 1 if apply_brake != 0 else 0,         #Enable brake lights
+    "EP1_HydrHalten": 1 if epb_enabled else 0,              #Disengage DSG
+    "EP1_AutoHold_aktiv": 1,                                #Signal indicating EPB is available
+  }
+
+  return packer.make_can_msg("EPB_1", bus, values)
 
 
 def create_acc_hud_control(packer, bus, acc_hud_status, set_speed, lead_distance):

--- a/selfdrive/car/volkswagen/values.py
+++ b/selfdrive/car/volkswagen/values.py
@@ -100,6 +100,7 @@ class CarControllerParams:
 
 class CANBUS:
   pt = 0
+  br = 1
   cam = 2
 
 


### PR DESCRIPTION
* initial EPB/ECD control commit

* EPB/ECD bugfix

* update EP1_AutoHold_aktiv value, fix panda spacing

* bugfix broken EPB_enabled check on cruiseState.available?

* remove unused import from carstate

* try fixing EPB_enable in carstate again

* bypass cruiseState.available for now

* fix cruiseState.available data type

* was a bit over-zealous trying that out

* my sanity is dwindling. more haxs

* change EPB can_sends from extend to append

* change EPB to brake below 11MPH, re-enable canValid